### PR TITLE
move lowpass, mrcread and mrcsave to utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .swp
 __pycache__/
 data/
+output/
 *.mrc

--- a/T356/test_lowpass.py
+++ b/T356/test_lowpass.py
@@ -1,40 +1,13 @@
-from math import sqrt
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import numpy as np
-from numpy.fft import rfftn, irfftn, fftshift, ifftshift
-import mrcfile
 
-def mrcread(fname, ret_voxel_size = False):
-    with mrcfile.open(fname, mode = 'r', permissive = True) as mrc:
-        data = np.array(mrc.data, np.float64, order = 'C')
-        voxel_size = mrc.voxel_size
-        assert(voxel_size.x == voxel_size.y == voxel_size.z)
-    return (data, voxel_size.x) if ret_voxel_size else data
-
-def mrcsave(fname, data, voxel_size = 0.):
-    with mrcfile.new(fname, overwrite = True) as mrc:
-        mrc.set_data(np.array(data, np.float32, order = 'C'))
-        mrc.voxel_size = voxel_size
-
-def lowpass(x, freq, voxel_size):
-    fx = rfftn(fftshift(x), norm = 'ortho')
-
-    n = x.shape[0]
-    assert(x.shape == (n, n, n))
-    for i in range(n):
-        for j in range(n):
-            for k in range(n // 2 + 1):
-                ii = i if i < n // 2 else i - n
-                jj = j if j < n // 2 else j - n
-                kk = k
-                radius = sqrt(ii ** 2 + jj ** 2 + kk ** 2)
-                if n * voxel_size < freq * radius:
-                    fx[i, j, k] = 0
-
-    x = ifftshift(irfftn(fx, norm = 'ortho'))
-    return x
+import sys
+sys.path.append('../')
+from utility import mrcread, mrcsave, fourier_lowpass
 
 if __name__ == '__main__':
-    (data, voxel_size) = mrcread('../data/CNG_Reference_000_B_Final.mrc', True)
-    print(data.shape)
-    data = lowpass(data, 10.0, 1.32)
-    mrcsave('cng_lowpass.mrc', data)
+    data = mrcread('../data/CNG_Reference_000_B_Final.mrc')
+    data = fourier_lowpass(data, 160 * 1.32 / 10.)
+    mrcsave('../output/cng_lowpass_10A.mrc', data)

--- a/utility/__init__.py
+++ b/utility/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from .filter import *
+from .mrcio import *
+
+__all__ = [
+    'fourier_lowpass',
+
+    'mrcread',
+    'mrcsave',
+]

--- a/utility/__main__.py
+++ b/utility/__main__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from time import time
+from utility import mrcread, mrcsave, fourier_lowpass
+
+def test_fourier_lowpass_3d():
+    (f, voxel_size) = mrcread('./data/cng_Reference_000_B_Final.mrc', True)
+    time1 = time()
+    box_size = f.shape[0]
+    f = fourier_lowpass(f, box_size * voxel_size / 10)
+    time2 = time()
+    print('Fourier lowpass of CNG done in %.5fs.' % (time2 - time1))
+    mrcsave('./output/cng_lowpass_10A.mrc', f, voxel_size)
+
+if __name__ == '__main__':
+    np.set_printoptions(precision = 3, suppress = True)
+
+    test_fourier_lowpass_3d()

--- a/utility/filter.py
+++ b/utility/filter.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from numpy.fft import fftshift, ifftshift, rfftn, irfftn
+from math import sqrt
+
+def fourier_lowpass(x, r):
+    '''
+    Fourier lowpass of a 3-D volume
+
+    Parameters
+    ==========
+    x : numpy.ndarray
+        x.ndim == 3
+    r : double
+        Cut-off frequency for Fourier lowpass.
+        The unit of r is the number of voxels.
+        The resolution is box_size * voxel_size / r.
+    '''
+    fx = rfftn(fftshift(x), norm = 'ortho')
+    for (i, j, k) in np.ndindex(fx.shape):
+        ii = i if i < fx.shape[0] // 2 else i - fx.shape[0]
+        jj = j if j < fx.shape[1] // 2 else j - fx.shape[1]
+        kk = k
+        rho = sqrt(ii ** 2 + jj ** 2 + kk ** 2)
+        if rho > r:
+            fx[i, j, k] = 0
+    return ifftshift(irfftn(fx, norm = 'ortho'))

--- a/utility/mrcio.py
+++ b/utility/mrcio.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import mrcfile
+
+def mrcread(fname, ret_voxel_size = False):
+    with mrcfile.open(fname, mode = 'r', permissive = True) as mrc:
+        data = np.array(mrc.data, np.float64, order = 'C')
+        voxel_size = mrc.voxel_size
+        assert(voxel_size.x == voxel_size.y == voxel_size.z)
+    return (data, voxel_size.x) if ret_voxel_size else data
+
+def mrcsave(fname, data, voxel_size = 0.0):
+    with mrcfile.new(fname, overwrite = True) as mrc:
+        mrc.set_data(np.array(data, np.float32, order = 'C'))
+        mrc.voxel_size = voxel_size


### PR DESCRIPTION
把`mrcread`, `mrcsave`和`fourier_lowpass`放到`utility`里面，因为这些是比较常用的操作，写好优化好之后放到一个地方，今后每个task里面的测试脚本可以反复调用。

`utility/`目录下面放上`__init__.py`，表示将它视为一个python package，具体问题参考python的package和import相关材料。

`utility/`目录下面放上`__main__.py`，表示这个package本身也可以当作一个脚本来运行，具体方法是：终端进入到`cryoEM/`目录下，直接`python -m utility`，就会运行这个脚本。

`uility/mrcio.py`中是`mrcread`和`mrcsave`函数，无改动，功能简单，无文档注释。

`utility/filter.py`中包括了`fourier_lowpass`函数，加入了文档，`r`还是采用了number of voxel的单位制，这样可以减少输入的参数，和resolution（以A为单位）的转换公式写在文档里，由调用者自行转换。改写了代码风格，目前只能处理三维数组，但可以做少量修改使得其可以经过少量修改就可以对一般ndim一般shape的数组进行低通滤波，留作习题。